### PR TITLE
Fix error ACPI SSDT-USB.aml

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -1251,7 +1251,7 @@
 			<key>SysReport</key>
 			<false/>
 			<key>Target</key>
-			<integer>67</integer>
+			<integer>0</integer>
 		</dict>
 		<key>Entries</key>
 		<array/>


### PR DESCRIPTION
That fix boot in latest EFI 7.0.9